### PR TITLE
修复重载方法中的歧义

### DIFF
--- a/src/main/java/com/github/hcsp/objectbasic/Main.java
+++ b/src/main/java/com/github/hcsp/objectbasic/Main.java
@@ -5,7 +5,7 @@ import java.util.HashMap;
 public class Main {
     public static void main(String[] args) {
         // 请修复这里的编译错误，令实际调用的方法是print(HashMap)
-        print(null);
+        print((HashMap) null);
     }
 
     public static void print(int i) {


### PR DESCRIPTION
匹配多个构造器时，且参数是null，则需要使用强制类型转换。
